### PR TITLE
Fix Query String Passed by Slack

### DIFF
--- a/src/zabbix-maintanance.coffee
+++ b/src/zabbix-maintanance.coffee
@@ -31,7 +31,7 @@ module.exports = (robot) ->
 
   robot.respond /zbx-maint\s(set)\s(["]?\w.*)\s(\d+)\s(["]?\w.*)/i, (msg) ->
 
-    zbxhostgroup  = msg.match[2]
+    zbxhostgroup  = msg.match[2].replace /https?:\/\//gi, ""
     zbxlength     = msg.match[3]
     zbxaction     = msg.match[1]
     zbxdesc       = "Created by #{msg.message.user.name} : " + msg.match[4]
@@ -63,4 +63,3 @@ module.exports = (robot) ->
       msg.send chunk.toString()
     proc.stdout.on 'end', () ->
       msg.send data.toString()
-


### PR DESCRIPTION
Hello @RafPe 

I really enjoy your hubot script and it works great for our team! However, I experienced a problem where passing in a fully qualified hostname, such as "hostname.site.domain.com", for the `-t` option in Slack, then it was interpolated as `http://hostname.site.domain.com`. This of course caused the query to fail since it didn't exist.

Please see the commits below that fixed this issue by adding a `.replace` method to remove the `http://`

I am currently running your scripts versions based on the master branch, since I could not get the npm package to function properly, but it looks like the result should still be the same.

If you would be willing to accept this change, do you want it submitted to the devel branch?

What do you think of the change and is there anything you think should be done differently?


Thanks,